### PR TITLE
fix: dag initialization phase error

### DIFF
--- a/src/components/Dag/index.js
+++ b/src/components/Dag/index.js
@@ -92,48 +92,55 @@ function Dag({ id = 'dag-viewer', children } = {}) {
     async () => {
       await loadDagJs();
       const Player = window.ConfluxDagPlayer;
-      const container = document.getElementById(id);
       const initialSubChains = await fetchDagData();
+      const container = document.getElementById(id);
 
-      player = await new Player({
-        backgroundColor: '0x0B3560',
-        doc: container,
-        playByDefault: 500,
-        pointSize,
-        globalRadius: 100,
-        defaultInterval: 500,
-        colors: [0x76e2e0, 0xc79af5, 0xe4dcef, 0xf2a9b7, 0xf2be81, 0xc29af5, 0xdfdcef, 0xeca987, 0xe087ad, 0x85cfe8, 0xe0e0e0],
-        chain: initialSubChains.pop().reverse(),
-        onBlockClick: ({ hash }) => {
-          window.open(`/blocksdetail/${hash}`);
-        },
-        onBlockMouseOver: ({ mesh, meshPosition }) => {
-          if (mesh.refBlocksInfo.length) {
-            let refHashes = '';
-            refHashes = 'Ref block hashes:\n';
-            // eslint-disable-next-line no-return-assign
-            mesh.refBlocksInfo.forEach(({ hash: refHash }, idx) => {
-              // there will be undefined hash
-              if (refHash) refHashes += `[${idx}]:${refHash}\n`;
-            });
-            const useRightArrow = meshPosition.x > document.getElementById(id).clientWidth / 2;
-            setTooltipOpt({
-              direction: useRightArrow ? 'right' : 'left',
-              text: refHashes,
-              style: {
-                transform: useRightArrow ? 'translateX(-100%)' : undefined,
-                left: `${useRightArrow ? meshPosition.x : meshPosition.x}px`,
-                top: `${meshPosition.y - pointSize}px`,
-              },
-            });
-            setMouseOverBlockWithRef(true);
-          }
-        },
-        onBlockMouseOut: () => {
-          setMouseOverBlockWithRef(false);
-        },
-        // debug: true,
-      });
+      if (container) {
+        player = await new Player({
+          backgroundColor: '0x0B3560',
+          doc: container,
+          playByDefault: 500,
+          pointSize,
+          globalRadius: 100,
+          defaultInterval: 500,
+          colors: [0x76e2e0, 0xc79af5, 0xe4dcef, 0xf2a9b7, 0xf2be81, 0xc29af5, 0xdfdcef, 0xeca987, 0xe087ad, 0x85cfe8, 0xe0e0e0],
+          chain: initialSubChains.pop().reverse(),
+          onBlockClick: ({ hash }) => {
+            window.open(`/blocksdetail/${hash}`);
+          },
+          onBlockMouseOver: ({ mesh, meshPosition }) => {
+            if (mesh.refBlocksInfo.length) {
+              let refHashes = '';
+              refHashes = 'Ref block hashes:\n';
+              // eslint-disable-next-line no-return-assign
+              mesh.refBlocksInfo.forEach(({ hash: refHash }, idx) => {
+                // there will be undefined hash
+                if (refHash) refHashes += `[${idx}]:${refHash}\n`;
+              });
+              const useRightArrow = meshPosition.x > document.getElementById(id).clientWidth / 2;
+              setTooltipOpt({
+                direction: useRightArrow ? 'right' : 'left',
+                text: refHashes,
+                style: {
+                  transform: useRightArrow ? 'translateX(-100%)' : undefined,
+                  left: `${useRightArrow ? meshPosition.x : meshPosition.x}px`,
+                  top: `${meshPosition.y - pointSize}px`,
+                },
+              });
+              setMouseOverBlockWithRef(true);
+            }
+          },
+          onBlockMouseOut: () => {
+            setMouseOverBlockWithRef(false);
+          },
+          // debug: true,
+        }).catch((err) => {
+          // know error when this component got unmounted while dag is initializing
+          // only throw unknown error
+          if (document.getElementById(id)) throw err;
+        });
+      }
+      if (!player) return;
       appendAllSubChain(player, initialSubChains);
       startFechingDagData.call(player);
     },


### PR DESCRIPTION
This commit fix two kinds of error
1. error when Dag component got unmounted while dag.js is still initializing the
tween.js and pixi.js. The error is something like "invalid container"
2. error when Dag component got unmounted while dag.js is initializing the 2D
viewer. The error is something like "can't read xxx from undefined" or "xxx is
not a function"
error 1 is resolved by check against the existence of container dom before
initialize dag's player instance
error 2 is resolved by add a flag to stop dag's render loop
`requestAnimationFrame` when player is destroyed.

resolve #185

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-scan/186)
<!-- Reviewable:end -->
